### PR TITLE
fixed setTranslate

### DIFF
--- a/pull-element.js
+++ b/pull-element.js
@@ -226,6 +226,11 @@
 			this.disable()
 		},
 		setTranslate: function(translateX, translateY) {
+            var state = this.state
+
+            state.translateX = translateX
+            state.translateY = translateY
+
 			extend(
 				this.target.style,
 				emptyTransitionStyle,


### PR DESCRIPTION
hello ，您好：
使用pull-element过程中发现一处不合理。

场景：
通过配置onPullLeftEnd和onPullRightEnd对节点左右滑动结束事件进行监听，接着调用setTranslate()方法移动节点,这时手动拖动节点使得onPullXXXEnd回调触发，发现回调方法里回传的translateX参数不包含setTranslate()产生的位移。

尝试解决：
在setTranslate()方法中记录下产生的位移。